### PR TITLE
Silence Hashie warnings

### DIFF
--- a/lib/simplefeed.rb
+++ b/lib/simplefeed.rb
@@ -1,6 +1,8 @@
 require 'hashie/extensions/symbolize_keys'
 require 'simplefeed/version'
 
+Hashie.logger = Logger.new(nil)
+
 ::Dir.glob(::File.expand_path('../simplefeed/*.rb', __FILE__)).each { |f| require_relative(f) }
 
 require 'simplefeed/providers/redis'


### PR DESCRIPTION
Hashie is raising the warning `WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#keys defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.` more than 30 times, flooding the logs.