### PR TITLE
Not sure how this is working for everyone else?

### DIFF
--- a/lib/simplefeed.rb
+++ b/lib/simplefeed.rb
@@ -1,5 +1,6 @@
 require 'hashie/extensions/symbolize_keys'
 require 'simplefeed/version'
+require 'hashie'
 
 Hashie.logger = Logger.new(nil)
 


### PR DESCRIPTION
I'm not able to boot rails without this require.  `Hashie.logger = Logger.new(nil)`  throws `simplefeed.rb:4:in `<main>': undefined method `logger=' for Hashie:Module (NoMethodError)`  That line has been around for an extremely long time, so clearly there is something unique to my environment. Sending PR for visibility. I'll step through my boot and try to figure out what went wrong with loading.

```
Rails 6.0.2.2
ruby 2.7.0p0
simple-feed (2.0.2)
```