### PR TITLE
Fix warn for Redis 5.0.0

### DIFF
--- a/lib/simplefeed/providers/redis/driver.rb
+++ b/lib/simplefeed/providers/redis/driver.rb
@@ -139,12 +139,10 @@ module SimpleFeed
           end
         end
 
-        def with_pipelined
+        def with_pipelined(&block)
           with_retries do
             with_redis do |redis|
-              redis.pipelined do |pipeline|
-                yield(pipeline)
-              end
+              redis.pipelined(&block)
             end
           end
         end

--- a/lib/simplefeed/providers/redis/driver.rb
+++ b/lib/simplefeed/providers/redis/driver.rb
@@ -142,8 +142,8 @@ module SimpleFeed
         def with_pipelined
           with_retries do
             with_redis do |redis|
-              redis.pipelined do
-                yield(redis)
+              redis.pipelined do |pipeline|
+                yield(pipeline)
               end
             end
           end


### PR DESCRIPTION
Hi!

Recently I have a following warn:

    Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

    redis.pipelined do
      redis.get("key")
    end

    should be replaced by

    redis.pipelined do |pipeline|
      pipeline.get("key")
    end

and I fixed it at this PR.


Thanks!
