### PR TITLE
remove hiredis require

### DIFF
--- a/lib/simplefeed/providers/redis/driver.rb
+++ b/lib/simplefeed/providers/redis/driver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'redis'
-require 'redis/connection/hiredis'
+# require 'redis/connection/hiredis'
 require 'connection_pool'
 require 'colored2'
 require 'hashie/mash'


### PR DESCRIPTION
DON'T MERGE OR DELETE THIS BRANCH UNTIL READING BELOW!!

See:
https://github.com/redis/redis-rb/issues/1178

This line is removed to allow installation of the Redis 7 gem which no longer allows "require 'redis/connection/hiredis'"
We can remove this because from here because we were not using hiredis anyway (we were forcing usage of the driver: :ruby directive)

For now, we will leave a reference to this remove_hiredis branch on the main productmotion gemfile - we should go back to using the main repo once the main repo supports the Redis 7 gem.

